### PR TITLE
✨ feat(interface.json): 把推图功能外置

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -83,6 +83,10 @@
             ]
         },
         {
+            "name": "推图模式（请先手动在游戏的页面中打开需要推图的页面，如当期活动、佚事等，然后再运行此任务）",
+            "entry": "StagePromotion_SwipeRightAndFindStage"
+        },
+        {
             "name": "局外演绎：黄昏的音序",
             "entry": "SeriesOfDusks",
             "param": {

--- a/assets/resource/base/pipeline/activity/StagePromotion.json
+++ b/assets/resource/base/pipeline/activity/StagePromotion.json
@@ -21,9 +21,9 @@
             122
         ],
         "upper": [
-            122,
-            122,
-            122
+            133,
+            135,
+            139
         ],
         "count": 80,
         "action": "Click",
@@ -47,11 +47,11 @@
             122
         ],
         "upper": [
-            122,
-            122,
-            122
+            133,
+            135,
+            139
         ],
-        "count": 160,
+        "count": 70,
         "action": "Click",
         "next": [
             "StagePromotion_ReadyForAction",
@@ -312,8 +312,6 @@
             "StagePromotion_Victory",
             "StagePromotion_Skip",
             "StagePromotion_ReadyForAction",
-            "StagePromotion_NextStage2",
-            "StagePromotion_NextStage1",
             "StagePromotion_Dialog_Right",
             "StagePromotion_Dialog_Left",
             "StagePromotion_Combating"


### PR DESCRIPTION
把推图功能外置，同时修改了一下upper的值，保证在佚事中也可以生效。

移除了
"StagePromotion_NextStage2",
"StagePromotion_NextStage1",

因为发现会有 bug，并且按道理应该不需要这两个任务。

此 pr 的逻辑是：保留之前的推图功能，此功能可以临时性为玩家提供了辅助，以便在推剧情时能够更顺利地完成。

#144 