### PR TITLE
fix: 启动包路径注入参数以支持全屏启动

### DIFF
--- a/assets/resource/base/pipeline/startup.json
+++ b/assets/resource/base/pipeline/startup.json
@@ -42,7 +42,7 @@
     },
     "Start1999": {
         "action": "StartApp",
-        "package": "com.shenlan.m.reverse1999/com.ssgame.mobile.gamesdk.frame.AppStartUpActivity"
+        "package": "com.shenlan.m.reverse1999/com.ssgame.mobile.gamesdk.frame.AppStartUpActivity --windowingMode 4"
     },
     "BluePochLogo": {
         "recognition": "TemplateMatch",

--- a/assets/resource/bilibili/pipeline/startup.json
+++ b/assets/resource/bilibili/pipeline/startup.json
@@ -1,6 +1,6 @@
 {
     "Start1999": {
         "action": "StartApp",
-        "package": "com.shenlan.m.reverse1999.bilibili/com.ssgame.mobile.gamesdk.frame.AppStartUpActivity"
+        "package": "com.shenlan.m.reverse1999.bilibili/com.ssgame.mobile.gamesdk.frame.AppStartUpActivity --windowingMode 4"
     }
 }

--- a/assets/resource/global_en/pipeline/startup.json
+++ b/assets/resource/global_en/pipeline/startup.json
@@ -1,6 +1,6 @@
 {
     "Start1999": {
         "action": "StartApp",
-        "package": "com.bluepoch.m.en.reverse1999"
+        "package": "com.bluepoch.m.en.reverse1999 --windowingMode 4"
     }
 }

--- a/assets/resource/global_jp/pipeline/startup.json
+++ b/assets/resource/global_jp/pipeline/startup.json
@@ -1,7 +1,7 @@
 {
     "Start1999": {
         "action": "StartApp",
-        "package": "com.bluepoch.m.jp.reverse1999.and"
+        "package": "com.bluepoch.m.jp.reverse1999.and --windowingMode 4"
     },
     "BluePochLogo": {
         "recognition": "TemplateMatch",


### PR DESCRIPTION
Waydroid 下启动游戏默认以窗口模式启动

![图片](https://github.com/user-attachments/assets/ebf95a0f-6b2a-43d0-88e9-3c5a6f277d9d)

注入参数 `--windowingMode 4` 以全屏启动游戏, 避免影响屏幕分辨率比例而造成模拟操作位置偏移

