### PR TITLE
perf: 修改活动页面的进入方式，减慢了找寻关卡的速度

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -97,12 +97,6 @@
         {
             "name": "轶事派遣",
             "entry": "Anecdote",
-            "pipeline_override": {
-                "EnterTheActivityMain": {
-                    "template_doc": "修改为当期活动入口的template",
-                    "template": "Combat/Activity/FolieETDeraison.png"
-                }
-            },
             "doc": "[size:15][color:tomato]1.请自行阅读角色故事后使用本功能[/color][/size]\n[size:15][color:tomato]2.请在当期轶事活动关闭后关闭本功能[/color][/size]"
         },
         {
@@ -1101,9 +1095,6 @@
                 {
                     "name": "活动：唐人街影画 19 艰难",
                     "pipeline_override": {
-                        "EnterTheActivityMain": {
-                            "template": "Combat/Activity/ChinatownFilmsEnterTheShow.png"
-                        },
                         "ActivityMainChapter": {
                             "expected": [
                                 "开",
@@ -1127,9 +1118,6 @@
                 {
                     "name": "活动：朔日手记 19 艰难 （复刻）",
                     "pipeline_override": {
-                        "EnterTheActivityMain": {
-                            "template": "Combat/Activity/ChinatownFilmsEnterTheShow.png"
-                        },
                         "ActivityReturn": {
                             "enabled": true,
                             "expected": "朔日"
@@ -1145,9 +1133,6 @@
                 {
                     "name": "活动：地球上最后的夜晚 20 艰难（已结束）",
                     "pipeline_override": {
-                        "EnterTheActivityMain": {
-                            "template": "Combat/Activity/TheLastEveningOnEarthEnterTheShow.png"
-                        },
                         "TargetStageName": {
                             "expected": "20"
                         },
@@ -1159,9 +1144,6 @@
                 {
                     "name": "活动：再见，来亚什基 16 艰难（已结束）",
                     "pipeline_override": {
-                        "ActivityEntry": {
-                            "next": "GoodbyeRaya"
-                        },
                         "TargetStageName": {
                             "expected": "16"
                         },
@@ -1173,9 +1155,6 @@
                 {
                     "name": "活动：飞驰，明日之城 18 艰难（已结束）",
                     "pipeline_override": {
-                        "ActivityEntry": {
-                            "next": "FloorItToTheGoldenCity"
-                        },
                         "TargetStageName": {
                             "expected": "18"
                         },
@@ -1187,9 +1166,6 @@
                 {
                     "name": "活动：77号往事 18 艰难（已结束）",
                     "pipeline_override": {
-                        "ActivityEntry": {
-                            "next": "Route77"
-                        },
                         "TargetStageName": {
                             "expected": "18"
                         },
@@ -1201,9 +1177,6 @@
                 {
                     "name": "活动：东区黎明 19 艰难（已结束）",
                     "pipeline_override": {
-                        "EnterTheActivityMain": {
-                            "template": "Combat/Activity/LondonDawningEnterTheShow.png"
-                        },
                         "TargetStageName": {
                             "expected": "19"
                         },

--- a/assets/resource/base/pipeline/combat.json
+++ b/assets/resource/base/pipeline/combat.json
@@ -474,6 +474,7 @@
             100,
             50
         ],
+        "duration": 400,
         "post_wait_freezes": 1,
         "post_delay": 0,
         "next": [

--- a/assets/resource/base/pipeline/combat_activity.json
+++ b/assets/resource/base/pipeline/combat_activity.json
@@ -27,14 +27,20 @@
     "EnterTheActivityMain": {
         "doc": "进入当期活动主界面",
         "recognition": "TemplateMatch",
-        "template_code": "Set in code",
+        "template": "StartUp/HomeFlag.png",
         "roi": [
-            885,
-            123,
-            340,
-            183
+            1022,
+            419,
+            194,
+            166
         ],
         "action": "Click",
+        "target": [
+            1103,
+            220,
+            28,
+            22
+        ],
         "post_delay": 3000,
         "post_wait_freezes": {
             "time": 500,


### PR DESCRIPTION
使用固定位置方式进入活动页面，尝试减慢了滑动找寻关卡的速度，防止滑动过快惯性移动导致点击失败（或许可以改一下wait_freezes的target框？）